### PR TITLE
Move the part of copying the observer's list in notify().

### DIFF
--- a/test/test-safety.js
+++ b/test/test-safety.js
@@ -62,4 +62,28 @@ describe("Safety: Data Race", function(){
         gSubject.notify("test", null);
         assert(flag === true, "other observers should be called.");
     });
+
+    it("if the observer adds the other one to the same subject in calling handleMessage() loop.", function(){
+        var o1 = {
+            handleMessage: function (data, topic) {
+                gSubject.add("test", o3);
+            }
+        };
+        var o2 = {
+            handleMessage: function (data, topic) {
+            }
+        };
+
+        var flag = false;
+        var o3 = {
+            handleMessage: function (data, topic) {
+                flag = true;
+            }
+        };
+
+        gSubject.add("test", o1);
+        gSubject.add("test", o2);
+        gSubject.notify("test", null);
+        assert(flag === false, "should not call the added observer when adding observers should be called.");
+    });
 });


### PR DESCRIPTION
We call `notify()` many times than `add()`/`remove()`. We need to speed up it.

`notify()` iteration refers to the list object being on the heap.
Even if this subject modifies the list related to the topic that this handle now, it make the new list which has no effect to the list iterated now. This approach is a pseudo "copy-on-write" which is based on the assumption that all object's lifetimes are handled by garbage collection. This is tricky approach.
- When adding an observer to the same topic (calling `add()`), we don't copy the current list and add the add the observer to the current list. Although this is destructive, its operation add the observer to the end of list. So it does not effect to the current iterated range of the list's length. It's would be safety.
- When removing an observer from the same topic (calling `remove()`), we copy the current list, modify it, and overwrite this object with it. Because to remove an observer from the same topic is destructive operation that will decrease the list's length. It is not safety. See `remove()` method.
- When removing the topic and observers related to it from this subject (calling `_removeTopic()` via `removeTopic()` or `destory()`), it's not safety. However, we don't make it safe. Because, it's bad approach that the observer calls `removeTopic()` with the topic which is passed to his `handleMessange`. It should be handled in each observers with using `remove()`, or the subject handle `removeTopic/destroy`.
# performance test
- [test case](https://gist.github.com/saneyuki/9243155)
  - `notify()`
  - `remove()`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/observer-js/32)

<!-- Reviewable:end -->
