### PR TITLE
Declare strict mode in the module name space

### DIFF
--- a/observer.js
+++ b/observer.js
@@ -26,9 +26,8 @@
  * THE SOFTWARE.
  */
 
-"use strict";
-
 var ObserverSubject = (function(){
+"use strict";
 
 // FIXME: for ~IE8
 var useFreeze = !!Object.freeze;


### PR DESCRIPTION
When to concatenate with other scripts, the old style might not enable strict mode.
